### PR TITLE
Add login support for Hyperspace client

### DIFF
--- a/docs/api/execute-test.md
+++ b/docs/api/execute-test.md
@@ -82,6 +82,8 @@ Argument | Description | Required
 `load-worker-coordinator-hosts` | Define a comma-separated list of hosts which should generate load (default: `localhost`). | No
 `client-options` | Define a comma-separated list of client options to use. The options will be passed to the OpenSearch Python client (default: `timeout:60`). | No
 `client_type` | Set to `hyperspace` to use the Hyperspace compatible client instead of the OpenSearch client. | No
+`login_user` | Username for the Hyperspace login API. Only used with `client_type:hyperspace`. | No
+`login_password` | Password for the Hyperspace login API. Only used with `client_type:hyperspace`. | No
 `on-error` | Controls how OSB behaves on response errors. Options are `continue` and `abort` (default: `continue`). | No
 `telemetry` | Enable the provided telemetry devices, provided as a comma-separated list. List possible telemetry devices with `opensearch-benchmark list telemetry`. | No
 `telemetry-params` | Define a comma-separated list of key:value pairs that are injected verbatim to the telemetry devices as parameters. | No

--- a/osbenchmark/client.py
+++ b/osbenchmark/client.py
@@ -45,6 +45,8 @@ class OsClientFactory:
         self.client_type = self.client_options.pop("client_type", "opensearch")
         self.token = self.client_options.pop("token", None)
         self.debug = self.client_options.pop("debug", False)
+        self.login_user = self.client_options.pop("login_user", None)
+        self.login_password = self.client_options.pop("login_password", None)
         self.ssl_context = None
         self.logger = logging.getLogger(__name__)
         self.aws_log_in_dict = {}
@@ -52,6 +54,8 @@ class OsClientFactory:
         masked_client_options = dict(client_options)
         if "basic_auth_password" in masked_client_options:
             masked_client_options["basic_auth_password"] = "*****"
+        if "login_password" in masked_client_options:
+            masked_client_options["login_password"] = "*****"
         if "http_auth" in masked_client_options:
             masked_client_options["http_auth"] = (masked_client_options["http_auth"][0], "*****")
         if "amazon_aws_log_in" in masked_client_options:
@@ -209,7 +213,14 @@ class OsClientFactory:
             from osbenchmark.hyperspace_client import HyperspaceClient
             host = self.hosts[0]
             timeout = int(self.client_options.get("timeout", 60))
-            return HyperspaceClient(host, timeout=timeout, token=self.token, debug=self.debug)
+            return HyperspaceClient(
+                host,
+                timeout=timeout,
+                token=self.token,
+                debug=self.debug,
+                login_user=self.login_user,
+                login_password=self.login_password,
+            )
 
         import opensearchpy
         from botocore.credentials import Credentials
@@ -231,7 +242,14 @@ class OsClientFactory:
             from osbenchmark.hyperspace_client import AsyncHyperspaceClient
             host = self.hosts[0]
             timeout = int(self.client_options.get("timeout", 60))
-            return AsyncHyperspaceClient(host, timeout=timeout, token=self.token, debug=self.debug)
+            return AsyncHyperspaceClient(
+                host,
+                timeout=timeout,
+                token=self.token,
+                debug=self.debug,
+                login_user=self.login_user,
+                login_password=self.login_password,
+            )
 
         import opensearchpy
         import osbenchmark.async_connection

--- a/osbenchmark/hyperspace_client.py
+++ b/osbenchmark/hyperspace_client.py
@@ -50,7 +50,7 @@ class _BaseClient(RequestContextHolder):
     def _login(self, username: str, password: str) -> None:
         """Authenticate against the login API and store the bearer token."""
         url = self._url("login")
-        self._debug_log(f"POST {url} username={username}")
+        self._debug_log(f"POST {url} username={username} password=*****")
         resp = requests.post(
             url,
             json={"username": username, "password": password},

--- a/osbenchmark/hyperspace_client.py
+++ b/osbenchmark/hyperspace_client.py
@@ -30,8 +30,10 @@ class _BaseClient(RequestContextHolder):
         self.debug = debug
         if token:
             self.headers["Authorization"] = f"Bearer {token}"
-        elif login_user and login_password:
-            self._login(login_user, login_password)
+        elif login_user is not None or login_password is not None:
+            if login_user is None or login_password is None:
+                raise ValueError("login_user and login_password must both be provided")
+            self._login(str(login_user), str(login_password))
 
         self.is_hyperspace = True
 
@@ -54,6 +56,7 @@ class _BaseClient(RequestContextHolder):
         resp = requests.post(
             url,
             json={"username": username, "password": password},
+            headers={"Content-Type": "application/json"},
             timeout=self.timeout,
         )
         resp.raise_for_status()

--- a/osbenchmark/hyperspace_client.py
+++ b/osbenchmark/hyperspace_client.py
@@ -53,10 +53,14 @@ class _BaseClient(RequestContextHolder):
         """Authenticate against the login API and store the bearer token."""
         url = self._url("login")
         self._debug_log(f"POST {url} username={username} password=*****")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
         resp = requests.post(
             url,
             json={"username": username, "password": password},
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             timeout=self.timeout,
         )
         resp.raise_for_status()

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -57,6 +57,17 @@ class OsClientFactoryTests(TestCase):
 
         self.assertDictEqual(original_client_options, client_options)
 
+    def test_hyperspace_login_options_removed(self):
+        hosts = [{"host": "localhost"}]
+        client_options = {"client_type": "hyperspace", "login_user": "user", "login_password": "pw"}
+        original_client_options = dict(client_options)
+
+        f = client.OsClientFactory(hosts, client_options)
+
+        self.assertNotIn("login_user", f.client_options)
+        self.assertNotIn("login_password", f.client_options)
+        self.assertDictEqual(original_client_options, client_options)
+
     @mock.patch.object(ssl.SSLContext, "load_cert_chain")
     def test_create_https_connection_verify_server(self, mocked_load_cert_chain):
         hosts = [{"host": "localhost", "port": 9200}]

--- a/tests/hyperspace_client_test.py
+++ b/tests/hyperspace_client_test.py
@@ -241,7 +241,7 @@ def test_wildcard_search_returns_empty(monkeypatch):
     client.close()
 
 
-def test_login_fetches_token(monkeypatch):
+def test_login_fetches_token(monkeypatch, capsys):
     captured = {}
 
     class Resp:
@@ -267,8 +267,10 @@ def test_login_fetches_token(monkeypatch):
     monkeypatch.setattr(HyperspaceClient, "on_request_start", lambda self: None)
     monkeypatch.setattr(HyperspaceClient, "on_request_end", lambda self: None)
 
-    client = HyperspaceClient({"host": "localhost"}, login_user="user", login_password="pw")
+    client = HyperspaceClient({"host": "localhost"}, login_user="user", login_password="pw", debug=True)
+    out = capsys.readouterr().out
     assert client.headers["Authorization"] == "Bearer abc"
     assert captured["json"] == {"username": "user", "password": "pw"}
     assert captured["url"].endswith("/login")
+    assert "password=*****" in out
     client.close()

--- a/tests/hyperspace_client_test.py
+++ b/tests/hyperspace_client_test.py
@@ -259,6 +259,7 @@ def test_login_fetches_token(monkeypatch, capsys):
     def dummy_post(url, json=None, headers=None, timeout=None):
         captured["url"] = url
         captured["json"] = json
+        captured["headers"] = headers
         return Resp()
 
     monkeypatch.setattr(requests, "post", dummy_post)
@@ -271,6 +272,7 @@ def test_login_fetches_token(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert client.headers["Authorization"] == "Bearer abc"
     assert captured["json"] == {"username": "user", "password": "pw"}
+    assert captured["headers"]["Accept"] == "application/json"
     assert captured["url"].endswith("/login")
     assert "password=*****" in out
     client.close()

--- a/tests/hyperspace_client_test.py
+++ b/tests/hyperspace_client_test.py
@@ -256,7 +256,7 @@ def test_login_fetches_token(monkeypatch, capsys):
         def json(self):
             return {"token": "abc"}
 
-    def dummy_post(url, json=None, timeout=None):
+    def dummy_post(url, json=None, headers=None, timeout=None):
         captured["url"] = url
         captured["json"] = json
         return Resp()
@@ -274,3 +274,10 @@ def test_login_fetches_token(monkeypatch, capsys):
     assert captured["url"].endswith("/login")
     assert "password=*****" in out
     client.close()
+
+
+def test_login_requires_both_credentials():
+    with pytest.raises(ValueError):
+        HyperspaceClient({"host": "localhost"}, login_user="user")
+    with pytest.raises(ValueError):
+        HyperspaceClient({"host": "localhost"}, login_password="pw")

--- a/tests/hyperspace_client_test.py
+++ b/tests/hyperspace_client_test.py
@@ -239,3 +239,36 @@ def test_wildcard_search_returns_empty(monkeypatch):
     assert captured["method"] == "POST"
     assert captured["url"].endswith("logs-*/dsl_search")
     client.close()
+
+
+def test_login_fetches_token(monkeypatch):
+    captured = {}
+
+    class Resp:
+        headers = {"Content-Type": "application/json"}
+
+        def __init__(self):
+            self.content = b'{"token":"abc"}'
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"token": "abc"}
+
+    def dummy_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", dummy_post)
+    monkeypatch.setattr(HyperspaceClient, "on_client_request_start", lambda self: None)
+    monkeypatch.setattr(HyperspaceClient, "on_client_request_end", lambda self: None)
+    monkeypatch.setattr(HyperspaceClient, "on_request_start", lambda self: None)
+    monkeypatch.setattr(HyperspaceClient, "on_request_end", lambda self: None)
+
+    client = HyperspaceClient({"host": "localhost"}, login_user="user", login_password="pw")
+    assert client.headers["Authorization"] == "Bearer abc"
+    assert captured["json"] == {"username": "user", "password": "pw"}
+    assert captured["url"].endswith("/login")
+    client.close()


### PR DESCRIPTION
## Summary
- support authenticating to Hyperspace using login API
- allow `login_user` and `login_password` client options
- mask login password in logs
- document the new options
- test login workflow and option parsing

## Testing
- `pytest -q tests/hyperspace_client_test.py::test_login_fetches_token tests/client_test.py::OsClientFactoryTests::test_hyperspace_login_options_removed`
- `pytest -q` *(fails: LaunchError, TypeError and BenchmarkError)*

------
https://chatgpt.com/codex/tasks/task_b_6879053740b88320af876c39059447a5